### PR TITLE
Corrected resolution of project.version in tags convention

### DIFF
--- a/src/main/java/me/itzg/simpleimg/BootImageExtension.java
+++ b/src/main/java/me/itzg/simpleimg/BootImageExtension.java
@@ -10,7 +10,7 @@ public abstract class BootImageExtension {
     void apply(Project project) {
         getBaseImage().convention(fromStringProperty(project, "imageBase", "eclipse-temurin:17"));
         getImageName().convention(fromStringProperty(project, "imageName", project.getName()));
-        getTags().convention(List.of("latest", project.getVersion().toString()));
+        getTags().convention(project.getProviders().provider(() -> List.of("latest", project.getVersion().toString())));
         getPullForBuild().convention(fromBooleanProperty(project, "imagePull", false));
         getPush().convention(resolvePushConvention(project));
         getLayered().convention(fromBooleanProperty(project, "imageLayered", true));

--- a/src/main/java/me/itzg/simpleimg/SimpleBootImagePlugin.java
+++ b/src/main/java/me/itzg/simpleimg/SimpleBootImagePlugin.java
@@ -1,9 +1,11 @@
 package me.itzg.simpleimg;
 
 
+import java.util.List;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.file.RegularFile;
+import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.bundling.AbstractArchiveTask;
 import org.gradle.api.tasks.bundling.Jar;


### PR DESCRIPTION
When using a gradle plugin to dynamically calculate project.version, the convention value of tags would end up with `unspecified`.